### PR TITLE
Convierte la tienda a WebApp 100% Google Apps Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,130 +1,204 @@
-# Demon Jewellery — Apps Script WebApp
+# Demon Jewellery — WebApp 100% Google Apps Script
 
-Sitio web completo para **Demon Jewellery | Brillante Estilo** con catálogo, pedidos, solicitudes de diseños personalizados, panel admin básico y almacenamiento en Google Sheets.
+Aplicación web para **Demon Jewellery | Brillante Estilo** ejecutada completamente en Google Apps Script y conectada a Google Sheets.
 
-## Qué incluye
+El repositorio se usa únicamente para versionar y desplegar el proyecto con `clasp`. La WebApp no descarga HTML, CSS, JavaScript ni configuración desde GitHub durante su ejecución.
+
+## Funciones incluidas
 
 - Catálogo público alimentado desde la hoja `Catalogo`.
-- Formulario de compra con folio, referencia de pago y apertura automática de WhatsApp.
-- Formulario de diseño personalizado con presupuesto, material, talla e imagen de referencia.
-- Consulta de pedido por folio + correo/WhatsApp.
-- Panel admin protegido por PIN para ver pedidos y diseños.
-- Auditoría de acciones en la hoja `Auditoria`.
-- Soporte para cargar HTML/CSS/JS y assets desde GitHub.
-- Assets incluidos en `/assets/img` y manifiesto en `/assets/manifest.json`.
+- Búsqueda y filtros por categoría.
+- Registro de pedidos con folio y referencia de pago.
+- Solicitudes de diseños personalizados.
+- Seguimiento por folio y dato de contacto.
+- Panel administrativo protegido por PIN.
+- Registro de auditoría en Google Sheets.
+- Interfaz adaptable para celular, tableta y escritorio.
+- Integración de contacto por WhatsApp.
 
-## Estructura
+## Arquitectura
 
 ```text
-src/                 Archivos que se suben a Apps Script con clasp
-frontend/            Copia remota del frontend para leerse desde GitHub
-assets/img/          Imágenes y logo de Demon Jewellery
-assets/manifest.json Manifiesto de imágenes
-assets-base64/       Respaldo textual de assets para GitHub si no se suben binarios
-docs/                Guías de instalación y esquema de hojas
+src/
+├── Code.gs          Entrada de la WebApp, setup y diagnóstico
+├── Config.gs        Configuración general
+├── Database.gs      Acceso y esquema de Google Sheets
+├── Catalogo.gs      Catálogo público
+├── Pedidos.gs       Pedidos, diseños y seguimiento
+├── Admin.gs         Operaciones administrativas
+├── Index.html       Interfaz principal
+├── Styles.html      Estilos incluidos localmente
+├── Scripts.html     JavaScript incluido localmente
+└── appsscript.json  Manifiesto de Apps Script
 ```
 
-## Instalación rápida con clasp
+Los archivos bajo `frontend/`, `assets/` o módulos remotos antiguos no son necesarios para ejecutar esta versión.
 
-1. Instala clasp:
+## Requisitos
+
+- Cuenta de Google.
+- Node.js instalado.
+- `clasp` instalado.
+- Una hoja de cálculo de Google Sheets.
+
+## Instalación con clasp
+
+### 1. Instalar clasp
 
 ```bash
 npm install -g @google/clasp
 clasp login
 ```
 
-2. Crea un proyecto Apps Script o usa uno existente.
+### 2. Clonar el repositorio
+
+```bash
+git clone https://github.com/soportehelpdeskusae-coder/usae.git
+cd usae
+git checkout agent/appscript-only
+```
+
+### 3. Crear un proyecto nuevo de Apps Script
+
+Desde la raíz del repositorio:
 
 ```bash
 clasp create --type webapp --title "Demon Jewellery" --rootDir src
 ```
 
-3. Copia el `scriptId` generado en `.clasp.json`. Puedes partir de `.clasp.json.template`.
+Esto crea el archivo `.clasp.json` con el `scriptId` del proyecto.
 
-4. Sube el código:
+Para usar un proyecto existente, crea `.clasp.json` con:
+
+```json
+{
+  "scriptId": "TU_SCRIPT_ID",
+  "rootDir": "src"
+}
+```
+
+### 4. Subir el código
 
 ```bash
 clasp push
 ```
 
-5. En Apps Script, ejecuta una vez:
+### 5. Configurar Google Sheets
+
+Abre el proyecto en Apps Script:
+
+```bash
+clasp open
+```
+
+Ejecuta una vez una de estas opciones:
 
 ```javascript
-setup()
+setup('https://docs.google.com/spreadsheets/d/ID_DE_TU_HOJA/edit');
 ```
 
-El sistema creará o validará las hojas `Catalogo`, `Pedidos`, `Disenos`, `Clientes`, `Auditoria` y `Configuracion`.
-
-6. Despliega como WebApp:
-
-- Ejecutar como: tu usuario.
-- Acceso: cualquier persona.
-
-## Conectar el sitio a GitHub para cargar frontend y assets
-
-Después de subir el repositorio a GitHub, ejecuta en Apps Script:
+O, si el proyecto está vinculado directamente a una hoja:
 
 ```javascript
-setupRemoteFromGitHub('soportehelpdeskusae-coder/usae', 'main')
+setup();
 ```
 
-Para repositorio privado:
+La función crea o valida estas pestañas:
+
+- `Catalogo`
+- `Pedidos`
+- `Disenos`
+- `Clientes`
+- `Auditoria`
+- `Configuracion`
+
+El PIN administrativo inicial es `1234`. Cámbialo antes de publicar:
 
 ```javascript
-setupRemoteFromGitHub('soportehelpdeskusae-coder/usae', 'main', 'GITHUB_TOKEN_SOLO_LECTURA')
+setAdminPin('UN_PIN_SEGURO');
 ```
 
-El backend `.gs` debe estar desplegado en Apps Script; Apps Script no puede reemplazar de forma segura todo el backend desde GitHub en tiempo real. El flujo correcto es:
+### 6. Comprobar la instalación
 
-- Código `.gs`: versionado en GitHub y desplegado con `clasp push`.
-- HTML/CSS/JS/assets: pueden cargarse desde GitHub con `DJ_USE_REMOTE_HTML=true`.
-- Base de datos: se mantiene en Google Sheets.
-
-## Cambiar PIN admin
-
-Ejecuta en Apps Script:
+Ejecuta:
 
 ```javascript
-setAdminPin('TU_PIN_NUEVO')
+diagnostico();
 ```
 
-El PIN inicial generado por `setup()` es `1234`. Cámbialo antes de producción.
-
-## Editar catálogo
-
-Edita la hoja `Catalogo`. Campos importantes:
-
-- `activo`: usa `SI` para mostrar el producto.
-- `destacado`: usa `SI` para marcar destacado.
-- `imagen`: puede ser URL completa o ruta relativa como `img/producto_01.jpg`.
-- `precioMXN`: usa número. Si es `0`, el sitio muestra `A cotizar`.
-
-## Assets incluidos
-
-Las imágenes principales pueden subirse a `assets/img`. También se puede usar el respaldo textual en `assets-base64/` para conservar todos los recursos dentro de GitHub aunque el conector no permita escribir binarios.
-
-## GitHub Pages / raw assets
-
-Si el repositorio es público, las imágenes se cargan con:
-
-```text
-https://raw.githubusercontent.com/OWNER/REPO/main/assets/img/archivo.jpg
-```
-
-Si quieres usar GitHub Pages o CDN, ejecuta:
+El resultado debe indicar:
 
 ```javascript
-setPublicAssetsBaseUrl('https://OWNER.github.io/REPO/assets/')
+ready: true
 ```
 
-## Archivos principales
+### 7. Desplegar como aplicación web
 
-- `src/Code.gs`: entrada WebApp y setup.
-- `src/Config.gs`: configuración global.
-- `src/GitHubRemote.gs`: lectura remota desde GitHub.
-- `src/Database.gs`: esquema y utilidades de Sheets.
-- `src/Catalogo.gs`: API pública del catálogo.
-- `src/Pedidos.gs`: compras, diseños y seguimiento.
-- `src/Admin.gs`: panel interno.
-- `src/Index.html`, `src/Styles.html`, `src/Scripts.html`: frontend local.
-- `frontend/*`: frontend remoto para GitHub.
+En Apps Script:
+
+1. Abre **Implementar > Nueva implementación**.
+2. Selecciona **Aplicación web**.
+3. En **Ejecutar como**, selecciona tu cuenta.
+4. En **Quién tiene acceso**, selecciona **Cualquier persona**.
+5. Pulsa **Implementar**.
+
+También puedes desplegar con `clasp`:
+
+```bash
+clasp version "Primera versión Apps Script"
+clasp deploy --description "Demon Jewellery WebApp"
+```
+
+## Configuración inicial del catálogo
+
+En la hoja `Catalogo`, usa las columnas creadas por `setup()`.
+
+Campos principales:
+
+- `productId`: identificador único, por ejemplo `DJ-001`.
+- `nombre`: nombre comercial.
+- `categoria`: collar, anillo, pulsera, dije, etc.
+- `descripcion`: descripción del producto.
+- `material`: plata, acero, chapa, etc.
+- `precioMXN`: precio numérico.
+- `stock`: cantidad disponible.
+- `imagen`: URL HTTPS pública de la fotografía.
+- `tags`: palabras separadas por comas.
+- `activo`: `SI` para mostrarlo.
+- `destacado`: `SI` para usarlo como producto destacado.
+
+Las imágenes pueden estar en Google Drive con enlace público, Google Photos mediante una URL directa o cualquier alojamiento HTTPS. Si una imagen no está disponible, la interfaz muestra un marcador gráfico integrado.
+
+## Actualizar la aplicación
+
+Después de modificar archivos dentro de `src/`:
+
+```bash
+clasp push
+clasp version "Descripción del cambio"
+clasp deploy --deploymentId TU_DEPLOYMENT_ID --description "Actualización"
+```
+
+## Seguridad
+
+- Cambia el PIN administrativo inicial.
+- No guardes contraseñas, tokens o claves privadas en `Config.gs`.
+- Usa Propiedades del script para información sensible.
+- Limita la edición de la hoja de cálculo a personal autorizado.
+- Revisa periódicamente la hoja `Auditoria`.
+- La aplicación solicita únicamente permisos de Google Sheets e identificación básica del usuario ejecutor.
+
+## Archivos de ejecución
+
+La versión 100% Apps Script utiliza directamente:
+
+- `src/Code.gs`
+- `src/Config.gs`
+- `src/Database.gs`
+- `src/Catalogo.gs`
+- `src/Pedidos.gs`
+- `src/Admin.gs`
+- `src/Index.html`
+- `src/Styles.html`
+- `src/Scripts.html`
+- `src/appsscript.json`

--- a/src/Code.gs
+++ b/src/Code.gs
@@ -1,77 +1,92 @@
 /**
- * Punto de entrada de la WebApp.
+ * Punto de entrada de la WebApp 100% Google Apps Script.
+ * El HTML, CSS y JavaScript se sirven desde los archivos del proyecto;
+ * no se descargan archivos de GitHub durante la ejecución.
  */
 function doGet(e) {
   const params = (e && e.parameter) ? e.parameter : {};
-  const page = params.page || 'home';
-  const useRemote = remote_isHtmlEnabled_();
-  let template;
-
-  try {
-    if (useRemote) {
-      template = HtmlService.createTemplate(remote_fetchText_('frontend/Index.remote.html'));
-    } else {
-      template = HtmlService.createTemplateFromFile('Index');
-    }
-  } catch (err) {
-    audit_('system', 'REMOTE_HTML_FALLBACK', 'WebApp', 'Index', String(err));
-    template = HtmlService.createTemplateFromFile('Index');
-  }
+  const template = HtmlService.createTemplateFromFile('Index');
 
   template.app = web_getClientConfig();
-  template.page = page;
+  template.page = params.page || 'home';
 
   return template.evaluate()
     .setTitle(DJ_CONFIG.APP_NAME + ' | ' + DJ_CONFIG.TAGLINE)
     .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL)
-    .addMetaTag('viewport', 'width=device-width, initial-scale=1');
-}
-
-function include(filename) {
-  return HtmlService.createHtmlOutputFromFile(filename).getContent();
-}
-
-function includeRemote(path) {
-  return remote_fetchText_(path);
+    .addMetaTag('viewport', 'width=device-width, initial-scale=1, viewport-fit=cover');
 }
 
 /**
- * Ejecuta esto una vez para crear/validar la hoja de cálculo.
- * Puedes pasar una URL de Google Sheets o dejarla vacía para usar la hoja activa.
+ * Inserta archivos HTML parciales del mismo proyecto de Apps Script.
+ * Se utiliza para incluir Styles.html y Scripts.html dentro de Index.html.
+ */
+function include(filename) {
+  if (!/^[A-Za-z0-9_-]+$/.test(String(filename || ''))) {
+    throw new Error('Nombre de archivo no válido.');
+  }
+  return HtmlService.createHtmlOutputFromFile(filename).getContent();
+}
+
+/**
+ * Ejecuta esta función una vez desde el editor de Apps Script.
+ * Si se proporciona una URL, la WebApp usará esa hoja de cálculo.
  */
 function setup(spreadsheetUrl) {
-  const ss = spreadsheetUrl ? db_setSpreadsheetByUrl_(spreadsheetUrl) : db_getSpreadsheet_();
+  const ss = spreadsheetUrl
+    ? db_setSpreadsheetByUrl_(spreadsheetUrl)
+    : db_getSpreadsheet_();
+
   db_ensureSchema_();
 
   const props = PropertiesService.getScriptProperties();
   if (!props.getProperty(DJ_CONFIG.PROPS.adminPin)) {
     props.setProperty(DJ_CONFIG.PROPS.adminPin, '1234');
   }
-  audit_('setup', 'SETUP_COMPLETED', 'Spreadsheet', ss.getId(), 'Esquema inicial creado/validado.');
-  return jsonOk_({ spreadsheetId: ss.getId(), spreadsheetUrl: ss.getUrl(), adminPinDefault: '1234' });
+
+  audit_(
+    'setup',
+    'SETUP_COMPLETED',
+    'Spreadsheet',
+    ss.getId(),
+    'Esquema inicial creado o validado para la WebApp local.'
+  );
+
+  return jsonOk_({
+    spreadsheetId: ss.getId(),
+    spreadsheetUrl: ss.getUrl(),
+    adminPinDefault: '1234',
+    runtime: 'APPS_SCRIPT_ONLY'
+  });
 }
 
 /**
- * Configura el repositorio GitHub desde donde se leerán HTML/assets remotos.
- * repoFullName: "owner/repo"
- * ref: rama/tag/commit, por ejemplo "main"
- * token: opcional. Para repos privados, usar token con permiso de lectura.
+ * Guarda explícitamente la hoja de cálculo usada por el proyecto.
  */
-function setupRemoteFromGitHub(repoFullName, ref, token) {
-  if (!repoFullName || repoFullName.indexOf('/') === -1) {
-    throw new Error('repoFullName debe tener formato owner/repo');
+function configurarHoja(spreadsheetUrl) {
+  if (!spreadsheetUrl) {
+    throw new Error('Debes proporcionar la URL de Google Sheets.');
   }
-  const props = PropertiesService.getScriptProperties();
-  props.setProperty(DJ_CONFIG.PROPS.githubRepo, repoFullName);
-  props.setProperty(DJ_CONFIG.PROPS.githubRef, ref || DJ_CONFIG.DEFAULT_BRANCH);
-  props.setProperty(DJ_CONFIG.PROPS.useRemoteHtml, 'true');
-  if (token) props.setProperty(DJ_CONFIG.PROPS.githubToken, token);
-  CacheService.getScriptCache().removeAll(['remote:frontend/Index.remote.html', 'remote:frontend/Styles.remote.html', 'remote:frontend/Scripts.remote.html']);
-  audit_('setup', 'GITHUB_REMOTE_CONFIGURED', 'GitHub', repoFullName, 'Ref: ' + (ref || DJ_CONFIG.DEFAULT_BRANCH));
-  return jsonOk_({ repoFullName: repoFullName, ref: ref || DJ_CONFIG.DEFAULT_BRANCH, remoteHtml: true });
+  const ss = db_setSpreadsheetByUrl_(spreadsheetUrl);
+  db_ensureSchema_();
+  return jsonOk_({ spreadsheetId: ss.getId(), spreadsheetUrl: ss.getUrl() });
 }
 
-function disableRemoteHtml() {
-  PropertiesService.getScriptProperties().setProperty(DJ_CONFIG.PROPS.useRemoteHtml, 'false');
-  return jsonOk_({ remoteHtml: false });
+/**
+ * Devuelve un diagnóstico básico para comprobar la instalación.
+ */
+function diagnostico() {
+  const ss = db_getSpreadsheet_();
+  const required = Object.keys(DJ_CONFIG.HEADERS);
+  const existing = ss.getSheets().map(function(sheet) { return sheet.getName(); });
+  const missing = required.filter(function(name) { return existing.indexOf(name) === -1; });
+
+  return jsonOk_({
+    appName: DJ_CONFIG.APP_NAME,
+    version: DJ_CONFIG.VERSION,
+    spreadsheetId: ss.getId(),
+    spreadsheetUrl: ss.getUrl(),
+    requiredSheets: required,
+    missingSheets: missing,
+    ready: missing.length === 0
+  });
 }

--- a/src/Config.gs
+++ b/src/Config.gs
@@ -1,14 +1,13 @@
 /**
- * Demon Jewellery — Configuración general
- * Mantén aquí los datos públicos de la tienda.
+ * Demon Jewellery — configuración general para Google Apps Script.
+ * Mantén aquí únicamente datos públicos de la tienda.
  */
 const DJ_CONFIG = {
   APP_NAME: 'Demon Jewellery',
   TAGLINE: 'Brillante Estilo',
-  VERSION: '1.0.0',
+  VERSION: '2.0.0',
   TIMEZONE: 'America/Mexico_City',
   CURRENCY: 'MXN',
-  DEFAULT_BRANCH: 'main',
   CONTACT: {
     whatsapp: '5215500000000',
     email: 'ventas@demonjewellery.com',
@@ -17,12 +16,7 @@ const DJ_CONFIG = {
   },
   PROPS: {
     spreadsheetId: 'DJ_SPREADSHEET_ID',
-    adminPin: 'DJ_ADMIN_PIN',
-    githubRepo: 'DJ_GITHUB_REPO',
-    githubRef: 'DJ_GITHUB_REF',
-    githubToken: 'DJ_GITHUB_TOKEN',
-    useRemoteHtml: 'DJ_USE_REMOTE_HTML',
-    publicAssetsBaseUrl: 'DJ_PUBLIC_ASSETS_BASE_URL'
+    adminPin: 'DJ_ADMIN_PIN'
   },
   SHEETS: {
     catalogo: 'Catalogo',
@@ -63,17 +57,16 @@ const DJ_CONFIG = {
     payment: ['PENDIENTE', 'VALIDANDO', 'PAGADO', 'RECHAZADO']
   },
   DEFAULT_ASSETS: {
-    logo: 'img/logo_demon_jewellery.png',
-    hero: 'img/producto_01.jpg',
-    producto1: 'img/producto_01.jpg',
-    producto2: 'img/producto_02.jpg',
-    producto3: 'img/producto_03.jpg',
-    producto4: 'img/producto_04.jpg'
+    logo: '',
+    hero: '',
+    producto1: '',
+    producto2: '',
+    producto3: '',
+    producto4: ''
   }
 };
 
 function web_getClientConfig() {
-  const props = PropertiesService.getScriptProperties();
   return {
     appName: DJ_CONFIG.APP_NAME,
     tagline: DJ_CONFIG.TAGLINE,
@@ -81,9 +74,9 @@ function web_getClientConfig() {
     currency: DJ_CONFIG.CURRENCY,
     contact: DJ_CONFIG.CONTACT,
     whatsappUrl: buildWhatsappUrl_('Hola, quiero información de Demon Jewellery.'),
-    assetBaseUrl: remote_getAssetBaseUrl_(),
-    defaultAssets: (typeof asset_getDefaultAssets_ === 'function') ? asset_getDefaultAssets_() : DJ_CONFIG.DEFAULT_ASSETS,
-    remoteHtml: props.getProperty(DJ_CONFIG.PROPS.useRemoteHtml) === 'true',
+    assetBaseUrl: '',
+    defaultAssets: DJ_CONFIG.DEFAULT_ASSETS,
+    runtime: 'APPS_SCRIPT_ONLY',
     categories: obtenerCategorias()
   };
 }
@@ -103,7 +96,9 @@ function money_(value) {
 }
 
 function toBool_(value) {
-  return String(value || '').trim().toUpperCase() === 'SI' || value === true || String(value).toLowerCase() === 'true';
+  return String(value || '').trim().toUpperCase() === 'SI' ||
+    value === true ||
+    String(value).toLowerCase() === 'true';
 }
 
 function clean_(value) {

--- a/src/appsscript.json
+++ b/src/appsscript.json
@@ -5,8 +5,6 @@
   "runtimeVersion": "V8",
   "oauthScopes": [
     "https://www.googleapis.com/auth/spreadsheets",
-    "https://www.googleapis.com/auth/script.external_request",
-    "https://www.googleapis.com/auth/script.scriptapp",
     "https://www.googleapis.com/auth/userinfo.email"
   ],
   "webapp": {


### PR DESCRIPTION
## Qué cambia

- La WebApp sirve `Index.html`, `Styles.html` y `Scripts.html` directamente desde Google Apps Script.
- Se elimina la carga de HTML remoto desde GitHub durante la ejecución.
- La configuración deja de depender de propiedades de GitHub o de un servicio de assets remoto.
- Se reducen los permisos del manifiesto a Google Sheets e identificación básica.
- Se agregan `configurarHoja()` y `diagnostico()` para facilitar la instalación.
- Se actualiza el README con el flujo completo de instalación, configuración y despliegue mediante `clasp`.

## Motivo

El proyecto mezclaba un backend desplegado en Apps Script con frontend descargado dinámicamente desde GitHub. Esta rama deja GitHub únicamente como control de versiones y usa Apps Script como plataforma completa de ejecución.

## Impacto

La tienda conserva catálogo, pedidos, diseños personalizados, seguimiento, administración, auditoría, Google Sheets y WhatsApp, pero ya no requiere acceso a GitHub en tiempo de ejecución.

## Validación

- Comparación contra `main`: 4 archivos modificados.
- La plantilla principal ya referencia `include('Styles')` e `include('Scripts')` locales.
- `doGet()` utiliza exclusivamente `HtmlService.createTemplateFromFile('Index')`.
- El manifiesto mantiene runtime V8 y despliegue WebApp anónimo.